### PR TITLE
Change AbstractParser.php to support all Json encoded strings

### DIFF
--- a/src/AbstractParser.php
+++ b/src/AbstractParser.php
@@ -42,7 +42,7 @@ abstract class AbstractParser
     {
         $patterns = [
             self::T_NUMBER => '\d+(?:\.\d+)?',
-            self::T_STRING => '\"[^\"]*\"',
+            self::T_STRING => '"(?:(?:(?=\\\\)\\\\(?:["\\\\\/bfnrt]|u[0-9a-fA-F]{4}))|[^"\\\\\0-\x1F\x7F]+)*"',
             self::T_BOOL => 'true|false',
             self::T_NULL => 'null',
             self::T_PAREN_OPEN => '\(',
@@ -275,7 +275,7 @@ abstract class AbstractParser
 
             switch ($value->type) {
                 case self::T_STRING:
-                    $value = trim($value->value, '"');
+                    $value = json_decode($value->value, flags: JSON_THROW_ON_ERROR);
                     break;
                 case self::T_NUMBER:
                     if (strpos($value->value, '.') !== false) {


### PR DESCRIPTION
According to the RFC, (https://datatracker.ietf.org/doc/html/rfc7644#section-3.4.2.2) the comparison value rules are built on JSON Data Interchange format ABNF rules. That means that a comparison value such as `"test\""` should be parsed as `test"`. However, the current implementation would not recognize this comparison value as a string.

Therefore, the following changed were made:
1. Use a more complex regex that should recognize all JSON encoded strings (https://stackoverflow.com/questions/32155133/regex-to-match-a-json-string).
2. Use `json_decode()` instead of `trim()` to decode a string comparison value. This fixes several issues, such as escaped quotes being trimmed.  