### PR TITLE
Add support for fieldnames starting with dollar-sign like $ref

### DIFF
--- a/src/AbstractParser.php
+++ b/src/AbstractParser.php
@@ -52,7 +52,7 @@ abstract class AbstractParser
             self::T_NEGATION => 'not\s+',
             self::T_LOG_OP => '\s+(?:and|or)\s+',
             self::T_COMP_OP => '\s(?:(?:eq|ne|co|sw|ew|gt|lt|ge|le)\s+|pr)',
-            self::T_NAME => '(?:(?:[^\"]+\:)+)?[\-\_a-z0-9]+(?:\.[\-\_a-z0-9]+)?',
+            self::T_NAME => '(?:(?:[^\"]+\:)+)?[\-\_a-z0-9\\$]+(?:\.[\-\_a-z0-9\\$]+)?',
         ];
 
         if ($mode === ParserMode::PATH) {

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -748,6 +748,31 @@ class FilterParserTest extends TestCase
     /**
      * @covers \Cloudstek\SCIM\FilterParser\AST\AbstractNode
      * @covers \Cloudstek\SCIM\FilterParser\AST\AttributePath
+     * @covers \Cloudstek\SCIM\FilterParser\AST\ValuePath
+     * @covers \Cloudstek\SCIM\FilterParser\AST\Comparison
+     */
+    public function testCompareStringDollarValuePath()
+    {
+        /** @var AST\ValuePath $valuePath */
+        $valuePath = self::$parser->parse('members[$ref eq "https://example.com/v2/Users/71ddacd2-a8e7-49b8-a5db-ae50d0a5bfd7"]');
+
+        $this->assertInstanceOf(AST\ValuePath::class, $valuePath);
+        $this->assertNull($valuePath->getParent());
+        $this->assertEquals(new AST\AttributePath(null, ['members']), $valuePath->getAttributePath());
+
+        /** @var AST\Comparison $node */
+        $node = $valuePath->getNode();
+
+        $this->assertInstanceOf(AST\Comparison::class, $node);
+        $this->assertSame($valuePath, $node->getParent());
+        $this->assertEquals(new AST\AttributePath(null, ['members', '$ref']), $node->getAttributePath());
+        $this->assertSame(AST\Operator::EQ, $node->getOperator());
+        $this->assertSame('https://example.com/v2/Users/71ddacd2-a8e7-49b8-a5db-ae50d0a5bfd7', $node->getValue());
+    }
+
+    /**
+     * @covers \Cloudstek\SCIM\FilterParser\AST\AbstractNode
+     * @covers \Cloudstek\SCIM\FilterParser\AST\AttributePath
      * @covers \Cloudstek\SCIM\FilterParser\AST\Comparison
      */
     public function testCompareStringScheme()


### PR DESCRIPTION
In my project a patch request is received from a third-party tool where the `$ref`-field is used to select the group member for removal:
```json
{
    "schemas":
    [
        "urn:ietf:params:scim:api:messages:2.0:PatchOp"
    ],
    "Operations":
    [
        {
            "op": "remove",
            "path": "members[$ref eq \"https://example.com/v2/Users/d46e22f1-74ab-4179-a576-a441a136a9d9\"]"
        }
    ]
}
```
The parser cannot parse this property and throws the following exception: `Nette\Tokenizer\Exception: Unexpected '$ref eq "h' on line 1, column 9.`

This PR fixes this issue by updating the `T_NAME`-regex. A test is added as prove.