### PR TITLE
Replace tokenizer with maintained fork

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
     },
     "require": {
         "php": "^8.1",
-        "nette/tokenizer": "^3.1"
+        "stella-maris/tokenizer": "^1.0.1"
 
     },
     "require-dev": {

--- a/src/AbstractParser.php
+++ b/src/AbstractParser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Cloudstek\SCIM\FilterParser;
 
 use Cloudstek\SCIM\FilterParser\Exception\UnexpectedValueException;
-use Nette\Tokenizer;
+use StellaMaris\Tokenizer;
 
 /**
  * Abstract parser.

--- a/src/Exception/UnexpectedValueException.php
+++ b/src/Exception/UnexpectedValueException.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Cloudstek\SCIM\FilterParser\Exception;
 
-use Nette\Tokenizer;
+use StellaMaris\Tokenizer;
 
 /**
  * Unexpected value exception.

--- a/src/FilterParser.php
+++ b/src/FilterParser.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Cloudstek\SCIM\FilterParser;
 
-use Nette\Tokenizer;
+use StellaMaris\Tokenizer;
 
 /**
  * SCIM Filter Parser.

--- a/src/FilterParserInterface.php
+++ b/src/FilterParserInterface.php
@@ -16,7 +16,7 @@ interface FilterParserInterface
      *
      * @param string $input SCIM filter.
      *
-     * @throws \Nette\Tokenizer\Exception
+     * @throws \StellaMaris\Tokenizer\Exception
      *
      * @return AST\Node|null
      */

--- a/src/PathParser.php
+++ b/src/PathParser.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Cloudstek\SCIM\FilterParser;
 
 use Cloudstek\SCIM\FilterParser\Exception\UnexpectedValueException;
-use Nette\Tokenizer;
+use StellaMaris\Tokenizer;
 
 /**
  * SCIM Path Parser.

--- a/src/PathParserInterface.php
+++ b/src/PathParserInterface.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Cloudstek\SCIM\FilterParser;
 
 use Cloudstek\SCIM\FilterParser\Exception\TokenizerException;
-use Nette\Tokenizer;
+use StellaMaris\Tokenizer;
 
 /**
  * SCIM Path Parser interface.

--- a/tests/FilterParserTest.php
+++ b/tests/FilterParserTest.php
@@ -7,7 +7,7 @@ namespace Cloudstek\SCIM\FilterParser\Tests;
 use Cloudstek\SCIM\FilterParser\AST;
 use Cloudstek\SCIM\FilterParser\FilterParser;
 use Cloudstek\SCIM\FilterParser\FilterParserInterface;
-use Nette\Tokenizer;
+use StellaMaris\Tokenizer;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/tests/PathParserTest.php
+++ b/tests/PathParserTest.php
@@ -7,7 +7,7 @@ namespace Cloudstek\SCIM\FilterParser\Tests;
 use Cloudstek\SCIM\FilterParser\AST;
 use Cloudstek\SCIM\FilterParser\PathParser;
 use Cloudstek\SCIM\FilterParser\PathParserInterface;
-use Nette\Tokenizer;
+use StellaMaris\Tokenizer;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -179,7 +179,7 @@ class PathParserTest extends TestCase
      */
     public function testConjunctionThrowsException()
     {
-        $this->expectException(\Nette\Tokenizer\Exception::class);
+        $this->expectException(\StellaMaris\Tokenizer\Exception::class);
         $this->expectExceptionMessage(
             'Unexpected  eq  on line 1, column 9.'
         );
@@ -193,7 +193,7 @@ class PathParserTest extends TestCase
      */
     public function testDisjunctionThrowsException()
     {
-        $this->expectException(\Nette\Tokenizer\Exception::class);
+        $this->expectException(\StellaMaris\Tokenizer\Exception::class);
         $this->expectExceptionMessage(
             'Unexpected  eq  on line 1, column 9.'
         );
@@ -209,7 +209,7 @@ class PathParserTest extends TestCase
      */
     public function testComparisonThrowsException()
     {
-        $this->expectException(\Nette\Tokenizer\Exception::class);
+        $this->expectException(\StellaMaris\Tokenizer\Exception::class);
         $this->expectExceptionMessage(
             'Unexpected  eq  on line 1, column 9.'
         );
@@ -224,7 +224,7 @@ class PathParserTest extends TestCase
      */
     public function testSubAttributeComparisonThrowsException()
     {
-        $this->expectException(\Nette\Tokenizer\Exception::class);
+        $this->expectException(\StellaMaris\Tokenizer\Exception::class);
         $this->expectExceptionMessage(
             'Unexpected  eq  on line 1, column 15.'
         );
@@ -238,7 +238,7 @@ class PathParserTest extends TestCase
      */
     public function testAttributeWithSchemeComparisonThrowsException()
     {
-        $this->expectException(\Nette\Tokenizer\Exception::class);
+        $this->expectException(\StellaMaris\Tokenizer\Exception::class);
         $this->expectExceptionMessage(
             'Unexpected  eq  on line 1, column 68.'
         );
@@ -252,7 +252,7 @@ class PathParserTest extends TestCase
      */
     public function testSubAttributeWithSchemeComparisonThrowsException()
     {
-        $this->expectException(\Nette\Tokenizer\Exception::class);
+        $this->expectException(\StellaMaris\Tokenizer\Exception::class);
         $this->expectExceptionMessage(
             'Unexpected  eq  on line 1, column 74.'
         );


### PR DESCRIPTION
Currently the nette/tokenizer is abandoned. This commit replaces that dependency with a maintained fork of the nette-tokenizer. The fork is tested up to PHP8.5 at this time of writing.

The fork is a drop-in replacement that does not even require any code-changes.